### PR TITLE
Fix missing imports

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -2,6 +2,8 @@
 
 namespace Novius\TranslationLoader;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Translation\FileLoader;
 use Novius\TranslationLoader\TranslationLoaders\TranslationLoader;
 


### PR DESCRIPTION
### Issue

1) It fails to install when other package is using translations in service provider.
2) Catch block doesn't work because `QueryException` is not imported, and then it fails because `Schema` is missing too

- Fix missing `QueryException` and `Schema` imports

![image](https://user-images.githubusercontent.com/36774784/185585988-516b484b-0a45-46f4-989f-7ab5953c290e.png)

![image](https://user-images.githubusercontent.com/36774784/185585498-55599b04-41f9-4e86-a6cb-27090a5c62a2.png)

