### PR TITLE
FIX: Use right classnames for QueryException & Schema

### DIFF
--- a/src/TranslationLoaderManager.php
+++ b/src/TranslationLoaderManager.php
@@ -2,6 +2,8 @@
 
 namespace Novius\TranslationLoader;
 
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Translation\FileLoader;
 use Novius\TranslationLoader\TranslationLoaders\TranslationLoader;
 


### PR DESCRIPTION
QueryException used not to be caught

Using a nonexistant Schema class would have thrown an exception